### PR TITLE
Include file timestamps

### DIFF
--- a/AdbFileManager/Form1.cs
+++ b/AdbFileManager/Form1.cs
@@ -85,7 +85,7 @@ namespace AdbFileManager {
         string sourceFileName = Convert.ToString(row.Cells[0].Value);
         progressbar.update(copied, filecount, directoryPath, destinationFolder, Convert.ToString(row.Cells[0].Value));
         string sourcePath = directoryPath + sourceFileName;
-        string command = $"adb pull \"{sourcePath}\" \"{destinationFolder.Replace('\\', '/')}\"";
+        string command = $"adb pull -a \"{sourcePath}\" \"{destinationFolder.Replace('\\', '/')}\"";
         adb(command);
         //MessageBox.Show(output);
         copied++;


### PR DESCRIPTION
Problem:
Timestamps are not copied when sending files from Phone to PC.

Solution:
Add the `-a` flag to `adb pull` so that file timestamps are copied.