### PR TITLE
Add delete file functionality for Android side

### DIFF
--- a/AdbFileManager/Form1.Designer.cs
+++ b/AdbFileManager/Form1.Designer.cs
@@ -61,6 +61,8 @@ namespace AdbFileManager {
             commandLink_installYes = new DarkCommandLink();
             commandLink_installGoAway = new DarkCommandLink();
             pictureBox1 = new PictureBox();
+            contextMenu_android = new ContextMenuStrip(components);
+            menuItem_delete = new ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)dataGridView_soubory).BeginInit();
             deco_panel4.SuspendLayout();
             panel_dolniTlacitka.SuspendLayout();
@@ -83,7 +85,22 @@ namespace AdbFileManager {
             dataGridView_soubory.CellMouseDoubleClick += dataGridView1_CellMouseDoubleClick;
             dataGridView_soubory.ColumnHeaderMouseDoubleClick += dataGridView1_ColumnHeaderMouseDoubleClick;
             dataGridView_soubory.KeyDown += dataGridView1_KeyDown;
-            // 
+            dataGridView_soubory.ContextMenuStrip = contextMenu_android;
+            //
+            // contextMenu_android
+            //
+            contextMenu_android.Items.AddRange(new ToolStripItem[] { menuItem_delete });
+            contextMenu_android.Name = "contextMenu_android";
+            contextMenu_android.Size = new Size(120, 26);
+            //
+            // menuItem_delete
+            //
+            menuItem_delete.Name = "menuItem_delete";
+            menuItem_delete.ShortcutKeys = Keys.Delete;
+            menuItem_delete.Size = new Size(119, 22);
+            menuItem_delete.Text = "Delete";
+            menuItem_delete.Click += menuItem_delete_Click;
+            //
             // timer1
             // 
             timer1.Interval = 500;
@@ -436,5 +453,7 @@ namespace AdbFileManager {
 		public Label label_textInstall;
 		public DarkCommandLink commandLink_installGoAway;
 		public DarkCommandLink commandLink_installYes;
+		private ContextMenuStrip contextMenu_android;
+		private ToolStripMenuItem menuItem_delete;
 	}
 }

--- a/AdbFileManager/Localization/strings.Designer.cs
+++ b/AdbFileManager/Localization/strings.Designer.cs
@@ -504,5 +504,47 @@ namespace AdbFileManager {
                 return ResourceManager.GetString("lsLLNotSupportedMessageTitle", resourceCulture);
             }
         }
+
+        public static string delete_confirm_single {
+            get {
+                return ResourceManager.GetString("delete_confirm_single", resourceCulture);
+            }
+        }
+
+        public static string delete_confirm_multiple {
+            get {
+                return ResourceManager.GetString("delete_confirm_multiple", resourceCulture);
+            }
+        }
+
+        public static string delete_title {
+            get {
+                return ResourceManager.GetString("delete_title", resourceCulture);
+            }
+        }
+
+        public static string delete_error {
+            get {
+                return ResourceManager.GetString("delete_error", resourceCulture);
+            }
+        }
+
+        public static string delete_error_title {
+            get {
+                return ResourceManager.GetString("delete_error_title", resourceCulture);
+            }
+        }
+
+        public static string delete_partial_error {
+            get {
+                return ResourceManager.GetString("delete_partial_error", resourceCulture);
+            }
+        }
+
+        public static string contextMenu_delete {
+            get {
+                return ResourceManager.GetString("contextMenu_delete", resourceCulture);
+            }
+        }
     }
 }

--- a/AdbFileManager/Localization/strings.resx
+++ b/AdbFileManager/Localization/strings.resx
@@ -355,4 +355,29 @@ Please enable Compatibility mode in settings, and then click Refresh.</value>
     <data name="lsLLNotSupportedMessageTitle" xml:space="preserve">
 	<value>-L not supported</value>
   </data>
+  <data name="delete_confirm_single" xml:space="preserve">
+    <value>Are you sure you want to permanently delete '{0}'?
+
+This action cannot be undone. Android does not have a recycle bin.</value>
+  </data>
+  <data name="delete_confirm_multiple" xml:space="preserve">
+    <value>Are you sure you want to permanently delete these {0} items?
+
+This action cannot be undone. Android does not have a recycle bin.</value>
+  </data>
+  <data name="delete_title" xml:space="preserve">
+    <value>Confirm Delete</value>
+  </data>
+  <data name="delete_error" xml:space="preserve">
+    <value>Failed to delete '{0}': {1}</value>
+  </data>
+  <data name="delete_error_title" xml:space="preserve">
+    <value>Delete Error</value>
+  </data>
+  <data name="delete_partial_error" xml:space="preserve">
+    <value>Deleted {0} of {1} items. Some items could not be deleted.</value>
+  </data>
+  <data name="contextMenu_delete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary

This PR implements file deletion functionality for the Android file browser, addressing issue #17.

### Features
- Delete key triggers deletion of selected files/folders (Windows Explorer-like behavior)
- Right-click context menu with Delete option
- Confirmation dialog before deletion, warning that Android has no recycle bin (permanent deletion)
- Support for deleting multiple files/folders at once
- Error handling with detailed messages for permission denied, file not found, read-only filesystem, etc.
- Auto-refresh file list after deletion

### Implementation Details

**Files modified:**
- `Form1.cs`: Added `deleteSelectedFiles()` method and Delete key handler in `dataGridView1_KeyDown()`
- `Form1.Designer.cs`: Added context menu (`contextMenu_android`) with Delete menu item
- `Localization/strings.resx` and `strings.Designer.cs`: Added localization strings for confirmation dialogs and error messages

**ADB commands used:**
- Files: `adb shell rm "{path}"`
- Directories: `adb shell rm -rf "{path}"`

### Test Plan
- [x] Delete single file with Delete key
- [x] Delete single folder with Delete key
- [x] Delete multiple files/folders
- [x] Cancel deletion with "No" button
- [x] Verify file list refreshes after deletion
- [x] Right-click context menu Delete option

Tested on Windows 11 + Xiaomi 14 (Android 16).

Fixes #17